### PR TITLE
Select maximum discount instead of first match (#13)

### DIFF
--- a/services/CallService.js
+++ b/services/CallService.js
@@ -15,7 +15,12 @@ const calculateCallCost = async (cityId, duration, timeOfDay) => {
   let durationInMinutes = duration / 60;
   let cost = durationInMinutes * ratePerMinute;
 
-  const discount = city.discounts.find((d) => durationInMinutes >= d.duration);
+  const discount = city.discounts
+    .filter((d) => durationInMinutes >= d.duration)
+    .reduce(
+      (best, d) => (d.discountRate > (best?.discountRate ?? 0) ? d : best),
+      null,
+    );
   if (discount) {
     cost *= 1 - discount.discountRate;
   }


### PR DESCRIPTION

## Issue
city.discounts.find() returned the first discount whose threshold did not exceed 
the call duration. With an array [10 min → 10%, 20 min → 20%] and a 25-minute call, 
a 10% discount was applied instead of 20%.

## Solution
Replaced find() with filter() + reduce() to explicitly search for the discount 
with the maximum discountRate among all eligible options.

## Testing
25-minute call, rate 2.50 UAH/min, discounts [10 min → 10%, 20 min → 20%]:
- Before: 56.25 UAH (10% discount)
- After: 50.00 UAH (20% discount)